### PR TITLE
fixed link to contribution.md on index

### DIFF
--- a/pages/index.md
+++ b/pages/index.md
@@ -220,7 +220,7 @@ Check out a live demo at http://jscut.org/jscut.html.
 
 Use [GitHub issues](https://github.com/cncjs/cncjs/issues) for requests.
 
-Pull requests welcome! Learn how to [contribute](CONTRIBUTING.md).
+Pull requests welcome! Learn how to [contribute](https://github.com/cncjs/cncjs.org/blob/master/CONTRIBUTING.md).
 
 ## Localization
 


### PR DESCRIPTION
contribution page link was bad, added a /pages but the contributing.md was in root. updated to have a static URL.