### PR TITLE
Updating x264 link

### DIFF
--- a/pages/docs/rpi-setup-guide/index.md
+++ b/pages/docs/rpi-setup-guide/index.md
@@ -553,7 +553,8 @@ sudo -i
 
 # INSTALL H264 SUPPORT
 cd /usr/src
-git clone git://git.videolan.org/x264
+git clone https://code.videolan.org/videolan/x264.git
+~~git clone git://git.videolan.org/x264~~
 cd x264
 ./configure --host=arm-unknown-linux-gnueabi --enable-static --disable-opencl
 make


### PR DESCRIPTION
old x264 link is broken -  https://code.videolan.org/videolan/x264.git is the new address 

(My error output is below)
root@raspberrypi:/usr/src# sudo git clone git://code.videolan.org/x264
Cloning into 'x264'...
fatal: unable to connect to code.videolan.org:
code.videolan.org[0: 88.191.250.9]: errno=Connection refused
code.videolan.org[1: 2a01:e0d:1:3:58bf:fa02:c0de:70]: errno=Network is unreachable