### PR TITLE
Update supported node.js versions to match cncjs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,6 @@ branches:
     - master
 
 before_install:
-  - npm install -g npm
   - npm --version
 
 script:

--- a/pages/index.md
+++ b/pages/index.md
@@ -51,18 +51,17 @@ A web-based interface for CNC milling controller running [Grbl](https://github.c
 
  Version | Supported Level
 :------- |:---------------
- <=0.12  | Unsupported
- 4       | <b>Recommended for production use</b>
- 5       | Supported
- 6       | <b>Recommended for production use</b>
- 7       | Supported
- 8       | Unsupported<br>Note: Will be supported in CNCjs 2.0
+ 4       | Dropped support
+ 6       | Supported
+ 8       | Supported
+ 10      | Recommended
+ 12      | Recommended
 
 ## Getting Started
 
 ### Node.js Installation
 
-Node.js 4 or higher is recommended. You can install [Node Version Manager](https://github.com/creationix/nvm) to manage multiple Node.js versions. If you have `git` installed, just clone the `nvm` repo, and check out the latest version:
+Node.js 8 or higher is recommended. You can install [Node Version Manager](https://github.com/creationix/nvm) to manage multiple Node.js versions. If you have `git` installed, just clone the `nvm` repo, and check out the latest version:
 ```
 git clone https://github.com/creationix/nvm.git ~/.nvm
 cd ~/.nvm
@@ -79,11 +78,11 @@ export NVM_DIR="$HOME/.nvm"
 
 Once installed, you can select Node.js versions with:
 ```
-nvm install 4
-nvm use 4
+nvm install 10
+nvm use 10
 ```
 
-If you're using Node.js 4 or earlier versions, it's recommended that you upgrade npm to the latest version. To upgrade, run:
+It's also recommended that you upgrade npm to the latest version. To upgrade, run:
 ```
 npm install npm@latest -g
 ```


### PR DESCRIPTION
The supported versions of Node shown on [cnc.js.org](https://cnc.js.org/) differ from the readme in cncjs/cncjs (and therefore the github repo and [npm package](https://www.npmjs.com/package/cncjs), and also on the [wiki](https://github.com/cncjs/cncjs/wiki/Installation)) which misled me when I was trying to install cnc.js.

I've made a minimal change to update the node versions specified, so that the file matches the main cnc.js readme, but if it's easier I'm happy to port the rest of the readme over so that it's consistent and simpler for new users? 

